### PR TITLE
Issue #4756: Transliterate URL aliases by default

### DIFF
--- a/core/modules/path/config/path.settings.json
+++ b/core/modules/path/config/path.settings.json
@@ -7,7 +7,7 @@
     "max_length": 100,
     "max_component_length": 100,
     "update_action": 2,
-    "transliterate": false,
+    "transliterate": true,
     "reduce_ascii": false,
     "ignore_words": "",
     "punctuation_double_quotes": 0,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4756